### PR TITLE
feat: Make root element id customizable

### DIFF
--- a/Inertia.php
+++ b/Inertia.php
@@ -22,6 +22,9 @@ class Inertia extends Component
 
     /** @var string */
     public $view = '@tebe/inertia/views/inertia';
+    
+    /** @var string */
+    public $rootElementId = 'app';
 
     /**
      * @inheritDoc

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ return [
     'components' => [
         'inertia' => [
             'class' => 'tebe\inertia\Inertia'
+            'rootElementId' => 'app' // optional per https://inertiajs.com/client-side-setup#defining-a-root-element
         ],
         'request' => [
             'cookieValidationKey' => '<cookie_validation_key>',

--- a/views/inertia.php
+++ b/views/inertia.php
@@ -1,4 +1,4 @@
 <?php
 /* @var $page array */
 ?>
-<div id="app" data-page="<?= htmlspecialchars(json_encode($page)) ?>"></div>
+<div id="<?= \Yii::$app->get('inertia')->rootElementId ?>" data-page="<?= htmlspecialchars(json_encode($page)) ?>"></div>


### PR DESCRIPTION
Allows users to make the Inertia root element's id customizable - so if `#app` is already used; another id can be defined.