### PR TITLE
fix inertiajs asset versioning

### DIFF
--- a/Inertia.php
+++ b/Inertia.php
@@ -68,11 +68,6 @@ class Inertia extends Component
             return;
         }
 
-        if ($response->isOk) {
-            $response->format = Response::FORMAT_JSON;
-            $response->headers->set('X-Inertia', 'true');
-        }
-
         if ($method === 'GET') {
             if ($request->headers->has('X-Inertia-Version')) {
                 $version = $request->headers->get('X-Inertia-Version', null, true);
@@ -82,6 +77,11 @@ class Inertia extends Component
                     return;
                 }
             }
+        }
+
+        if ($response->isOk) {
+            $response->format = Response::FORMAT_JSON;
+            $response->headers->set('X-Inertia', 'true');
         }
 
         if ($response->getIsRedirection()) {


### PR DESCRIPTION
Full reloads on 409 response now seems to not working due response has 'X-Inertia' header, with the suggested fix inertiajs correctly do full reload on 409 response.